### PR TITLE
Repository Languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.html linguist-detectable=false
+*.ipynb linguist-detectable=false


### PR DESCRIPTION
It seems like the language distribution is not visible in branches or previous commits. I tried to go to commit from 2023, and it is identical there to the current one. Probably for effect, we need to merge it first.